### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ optional arguments:
                         The latest date from which you want to see data in the heatmap.
   -s, --stream          Option to iteratively load data.
   --map MAP, -m MAP     The name of the map tiles you want to use.
-                        (e.g. 'OpenStreetMap', 'Stamen Terrain', 'Stamen Toner')
+                        (e.g. 'OpenStreetMap', 'StamenTerrain', 'StamenToner')
 ```
 
 ### 6. Review the Results


### PR DESCRIPTION
there should not be a space between the Stamen map type names when running in the windows command prompt