### PR TITLE
Remove argparse.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 beautifulsoup4
 folium
 progressbar2
-argparse
 ijson


### PR DESCRIPTION
As it is part of the standard library since Python 2.7 and 3.2,
there is no need to list it as dependency.
This causes conda install to fail with an UnsatisfiableError