### PR TITLE
Add support for GPX files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Here you can download all of the data that Google has stored on you: <https://ta
 
 To use this script, you only need to select and download your "Location History", which Google will provide to you as a JSON file by default.  KML is also an output option and is accepted for this program.
 
+You can also import [GPS Exchange Format (GPX)](https://en.wikipedia.org/wiki/GPS_Exchange_Format) files,
+e.g. from a GPS tracker.
+
 ### 3. Clone This Repository
 
 On <https://github.com/luka1199/geo-heatmap>, click the green "Clone or Download" button at the top right of the page. If you want to get started with this script more quickly, click the "Download ZIP" button, and extract the ZIP somewhere on your computer.
@@ -39,9 +42,10 @@ python geo_heatmap.py <file> [<file> ...]
 
 Replace the string `<file>` from above with the path to any of the following files:
 
-1. The `Location History.json` JSON file from Google Takeout
-2. The `Location History.kml` KML file from Google Takeout
-3. The `takeout-*.zip` raw download from Google Takeout that contains either of the above files
+- The `Location History.json` JSON file from Google Takeout
+- The `Location History.kml` KML file from Google Takeout
+- [GPS Exchange Format (GPX)](https://en.wikipedia.org/wiki/GPS_Exchange_Format) files
+- The `takeout-*.zip` raw download from Google Takeout that contains either of the above files
 
 #### Examples:
 

--- a/geo_heatmap.py
+++ b/geo_heatmap.py
@@ -228,10 +228,10 @@ if __name__ == "__main__":
     parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
     parser.add_argument(
         "files", metavar="file", type=str, nargs='+', help="Any of the following files:\n"
-        "1. Your location history JSON file from Google Takeout\n"
-        "2. Your location history KML file from Google Takeout\n"
-        "3. A GPX file containing GPS tracks\n"
-        "4. The takeout-*.zip raw download from Google Takeout \nthat contains either of the above files")
+        "- Your location history JSON file from Google Takeout\n"
+        "- Your location history KML file from Google Takeout\n"
+        "- A GPX file containing GPS tracks\n"
+        "- The takeout-*.zip raw download from Google Takeout \nthat contains either of the above files")
     parser.add_argument("-o", "--output", dest="output", metavar="", type=str, required=False,
                         help="Path of heatmap HTML output file.", default="heatmap.html")
     parser.add_argument("--min-date", dest="min_date", metavar="YYYY-MM-DD", type=str, required=False,


### PR DESCRIPTION
Add support for [GPS Exchange Format files](https://en.wikipedia.org/wiki/GPS_Exchange_Format)

This implementation looks only for tracks,
and expects that all track points have a
valid latitude, longitude, and time.