### PR TITLE
Fix "JSON file has no timestampMs field" error

### DIFF
--- a/geo_heatmap.py
+++ b/geo_heatmap.py
@@ -86,12 +86,17 @@ class Generator:
         w = [Bar(), Percentage(), " ", ETA()]
         with ProgressBar(max_value=max_value_est, widgets=w) as pb:
             for i, loc in enumerate(locations):
+                # Find the correct key for timestamps
+                # This is done in the loop because the data are streamed
+                if i == 0:
+                    key_timestamp = self.find_timestamp_key(loc)
+
                 if "latitudeE7" not in loc or "longitudeE7" not in loc:
                     continue
                 coords = (round(loc["latitudeE7"] / 1e7, 6),
                             round(loc["longitudeE7"] / 1e7, 6))
 
-                if timestampInRange(loc["timestampMs"], date_range):
+                if timestampInRange(loc[key_timestamp], date_range):
                     self.updateCoord(coords)
 
                 if i > max_value_est:

--- a/geo_heatmap.py
+++ b/geo_heatmap.py
@@ -29,7 +29,7 @@ class Generator:
         }
 
     @staticmethod
-    def find_timestamp_key(json_element):
+    def findTimestampKey(json_element):
         """Find the correct key for timestamps - Google changed this in early 2022.
         Earlier, the correct key was "timestampMs".
         Now, it is "timestamp".
@@ -55,7 +55,7 @@ class Generator:
 
         # Find the correct key for timestamps
         first_element = data["locations"][0]
-        key_timestamp = self.find_timestamp_key(first_element)
+        key_timestamp = self.findTimestampKey(first_element)
 
         w = [Bar(), Percentage(), " ", ETA()]
         with ProgressBar(max_value=len(data["locations"]), widgets=w) as pb:
@@ -89,7 +89,7 @@ class Generator:
                 # Find the correct key for timestamps
                 # This is done in the loop because the data are streamed
                 if i == 0:
-                    key_timestamp = self.find_timestamp_key(loc)
+                    key_timestamp = self.findTimestampKey(loc)
 
                 if "latitudeE7" not in loc or "longitudeE7" not in loc:
                     continue

--- a/geo_heatmap.py
+++ b/geo_heatmap.py
@@ -28,6 +28,20 @@ class Generator:
             "Data points": 0
         }
 
+    @staticmethod
+    def find_timestamp_key(json_element):
+        """Find the correct key for timestamps - Google changed this in early 2022.
+        Earlier, the correct key was "timestampMs".
+        Now, it is "timestamp".
+        This function simply tries to find these keys in the first data element.
+        """
+        if "timestampMs" in json_element.keys():  # Old data
+            key_timestamp = "timestampMs"
+        else:  # New data
+            key_timestamp = "timestamp"
+
+        return key_timestamp
+
     def loadJSONData(self, json_file, date_range):
         """Loads the Google location data from the given json file.
 
@@ -38,11 +52,10 @@ class Generator:
                 e.g.: (None, None), (None, '2019-01-01'), ('2017-02-11'), ('2019-01-01')
         """
         data = json.load(json_file)
-        # Find the correct key for timestamps - Google changed this in early 2022
-        if "timestampMs" in data["locations"][0].keys():  # Old data
-            key_timestamp = "timestampMs"
-        else:  # New data
-            key_timestamp = "timestamp"
+
+        # Find the correct key for timestamps
+        first_element = data["locations"][0]
+        key_timestamp = self.find_timestamp_key(first_element)
 
         w = [Bar(), Percentage(), " ", ETA()]
         with ProgressBar(max_value=len(data["locations"]), widgets=w) as pb:


### PR DESCRIPTION
I've implemented a fix for the problem described in issue #53. There is now a function that checks whether `"timestamp"` or `"timestampMs"` is the correct key to use. This works for both streaming and non-streaming JSON inputs.

I have tested this with a new (`"timestamp"`) JSON file and a KML file (which should not be affected in any way). Both work. Unfortunately, I do not have any old (`"timestampMs"`) files anymore, so please test it with one!

The other changes are simply some white space removal done automatically by my editor.