### PR TITLE
Custom colour maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ optional arguments:
   -mz MAX_ZOOM, --max-zoom MAX_ZOOM
                         The maximum zoom of the heatmap. (default: 4)
   -c COLOR_MAP, --color-map COLOR_MAP
-						The color map to use, from:
-						branca (<name>), matplotlib (mpl.<name>), cmcrameri (cmc.<name>)
+                        The color map to use, from:
+                        branca (<name>), matplotlib (mpl.<name>), cmcrameri (cmc.<name>)
 ```
 
 ### 6. Review the Results

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ Set a date range:
 python geo_heatmap.py --min-date 2017-01-02 --max-date 2018-12-30 Records.json
 ```
 
+Change the color map:
+```shell
+python geo_heatmap.py -c Set1_09 Records.json
+```
+
 Advanced heatmap settings:
 
 ```shell
@@ -123,6 +128,9 @@ optional arguments:
                         The minimum opacity of the heatmap. (default: 0.2)
   -mz MAX_ZOOM, --max-zoom MAX_ZOOM
                         The maximum zoom of the heatmap. (default: 4)
+  -c COLOR_MAP, --color-map COLOR_MAP
+						The color map to use, from:
+						branca (<name>), matplotlib (mpl.<name>), cmcrameri (cmc.<name>)
 ```
 
 ### 6. Review the Results

--- a/geo_heatmap.py
+++ b/geo_heatmap.py
@@ -208,6 +208,7 @@ class Generator:
         blur = settings["blur"]
         min_opacity = settings["min_opacity"]
         max_zoom = settings["max_zoom"]
+        color_map = settings["color_map"]
 
         map_data = [(coords[0], coords[1], magnitude)
                     for coords, magnitude in self.coordinates.items()]
@@ -219,12 +220,14 @@ class Generator:
                        attr="<a href=https://github.com/luka1199/geo-heatmap>geo-heatmap</a>")
 
         # Generate heat map
+        gradient = getColormapAsGradient(color_map) if color_map else None
         heatmap = HeatMap(map_data,
                           max_val=self.max_magnitude,
                           min_opacity=min_opacity,
                           radius=radius,
                           blur=blur,
-                          max_zoom=max_zoom)
+                          max_zoom=max_zoom,
+                          gradient=gradient)
 
         m.add_child(heatmap)
         return m
@@ -307,7 +310,9 @@ if __name__ == "__main__":
                         help="The minimum opacity of the heatmap. (default: %(default)s)", default=0.2)
     parser.add_argument("-mz", "--max-zoom", dest="max_zoom", type=int, required=False,
                         help="The maximum zoom of the heatmap. (default: %(default)s)", default=4)
-
+    parser.add_argument("-c", "--color-map", dest="color_map", type=str, required=False,
+                        help="The color map to use.\n" \
+                        "(from branca (default), matplotlib ('mpl.<name>'), cmcrameri ('cmc.<name>').", default=None)
 
     args = parser.parse_args()
     data_file = args.files
@@ -320,7 +325,8 @@ if __name__ == "__main__":
         "radius": args.radius,
         "blur": args.blur,
         "min_opacity": args.min_opacity,
-        "max_zoom": args.max_zoom
+        "max_zoom": args.max_zoom,
+        "color_map": args.color_map,
     }
 
     generator = Generator()

--- a/geo_heatmap.py
+++ b/geo_heatmap.py
@@ -311,8 +311,8 @@ if __name__ == "__main__":
     parser.add_argument("-mz", "--max-zoom", dest="max_zoom", type=int, required=False,
                         help="The maximum zoom of the heatmap. (default: %(default)s)", default=4)
     parser.add_argument("-c", "--color-map", dest="color_map", type=str, required=False,
-                        help="The color map to use.\n" \
-                        "(from branca (default), matplotlib ('mpl.<name>'), cmcrameri ('cmc.<name>').", default=None)
+                        help="The color map to use, from:\n" \
+                        "branca (<name>), matplotlib (mpl.<name>), cmcrameri (cmc.<name>).", default=None)
 
     args = parser.parse_args()
     data_file = args.files

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+import numpy as np
 import webbrowser
 
 
@@ -63,3 +64,47 @@ def dateInRange(date, date_range) -> bool:
     date = datetime.strptime(date, "%Y-%m-%d")
     return (min_date is None or min_date <= date) and \
         (max_date is None or max_date >= date)
+
+
+def getColormapAsGradient(name: str, n_steps: int=20) -> dict[int, str]:
+    """Returns the desired colormap in gradient format.
+
+    Colormaps are retrieved from branca.colormap.linear by default.
+    Names starting with mpl. are retrieved from matplotlib (optional import).
+    Names starting with cmc. are retrieved from cmcrameri (optional import).
+
+    Arguments:
+        name {str} -- Colormap name
+
+    Returns:
+        dict -- Keys are a range from 0 to 1, values are hex strings.
+    """
+    # Define steps
+    steps = np.linspace(0, 1, n_steps)
+
+    # Default behavior: Get from branca
+    if "." not in name or name.lower().startswith("branca."):
+        from branca.colormap import linear as cm
+        cmap = getattr(cm, name)
+        gradient = {i: cmap(i) for i in steps}
+
+    # Get from defined library
+    else:
+        lib, name = name.split(".")
+        lib = lib.lower()
+
+        # Matplotlib and derivatives
+        if lib in ("mpl", "cmc"):
+            from matplotlib.colors import to_hex
+            if lib == "mpl":
+                from matplotlib import colormaps as cm
+                cmap = cm.get_cmap(name)
+            elif lib == "cmc":
+                from cmcrameri import cm
+                cmap = getattr(cm, name)
+            gradient = {i: to_hex(cmap(i)) for i in steps}
+
+        else:
+            raise ValueError(f"Unknown colormap library '{lib}'.")
+
+    return gradient

--- a/utils.py
+++ b/utils.py
@@ -74,7 +74,8 @@ def getColormapAsGradient(name: str, n_steps: int=20) -> dict[int, str]:
     Names starting with cmc. are retrieved from cmcrameri (optional import).
 
     Arguments:
-        name {str} -- Colormap name
+        name {str} -- Colormap name.
+        n_steps {int} -- Number of quantization steps.
 
     Returns:
         dict -- Keys are a range from 0 to 1, values are hex strings.


### PR DESCRIPTION
I've added the ability to use different colour maps. While the default is great most of the time, this change should allow for more customisation without adding too much complexity.

The colour map can be selected in the terminal using the `-c` or `--color-map` argument with the name of the colour map. By default, the map will be imported from [branca](https://python-visualization.github.io/folium/latest/advanced_guide/colormaps.html#Built-in) (which folium requires, so no new dependencies). Additional options are [matplotlib](https://matplotlib.org/stable/users/explain/colors/colormaps.html#classes-of-colormaps) (`mpl.<name>`) and [cmcrameri](https://www.fabiocrameri.ch/colourmaps/) (`cmc.<name>`) – these are only imported when used, so it only adds optional dependencies. The selected colour map is converted into a gradient of hex strings, because this is what the folium `HeatMap` plugin requires; support for directly passing a colour map object should be added to folium at some point.

Some examples:

1. Default (no change)
![ghm default](https://github.com/user-attachments/assets/289eef69-7968-4337-905f-732c33b6ba8c)

2. `Paired_12`
![ghm Paired_12](https://github.com/user-attachments/assets/1e27930e-a758-46c3-bd84-72e7e2dacf21)

3. `Set1_09` with blur `-b 2`
![ghm Set1_09 -b2](https://github.com/user-attachments/assets/050c8232-41e7-416c-933a-70c123d05ef0)

4. `mpl.cividis`
![ghm mpl cividis](https://github.com/user-attachments/assets/718e334a-77cc-42b2-bd48-0eb9243dd428)

5. `cmc.lajolla` with blur `-b 2`
![ghm cmc lajolla -b2](https://github.com/user-attachments/assets/564159bf-5455-4cf5-9cca-bbc6fc1bb58d)
